### PR TITLE
Added user-agent recommendation to context attributes docsumentation

### DIFF
--- a/docs/SDK-Documentation/Advanced/context-attributes/setting-context-attributes/_setting-context-attributes.mdx
+++ b/docs/SDK-Documentation/Advanced/context-attributes/setting-context-attributes/_setting-context-attributes.mdx
@@ -30,6 +30,11 @@ can be used later in the Web Console to create segments or audiences. They can
 be set using the `attribute()` or `attributes()` methods, before or after the
 context is ready.
 
+One of the most useful and commonly used attributes, is the `user_agent` attribute
+which, when passed to the SDK, will be split up into multiple attributes that
+can be used to target specific browsers or devices in the Web Console. You can read
+more about how this works in [the Segments section of the Dashboard Settings docs](/docs/web-console-docs/settings#segments).
+
 <Tabs groupId="language">
 
 <TabItem value="js" label="Javascript">


### PR DESCRIPTION
This PR adds a recommendation and some information about passing the `user_agent` as a context attribute to the SDK. As well as pointing to information about the `UA Parser`