### PR TITLE
Custom Fields in Code example

### DIFF
--- a/docs/SDK-Documentation/Advanced/using-custom-fields-in-your-code.mdx
+++ b/docs/SDK-Documentation/Advanced/using-custom-fields-in-your-code.mdx
@@ -1,0 +1,73 @@
+# Custom Fields in Code
+
+In the [Platform Settings on the Web Console](/docs/web-console-docs/settings#platform-settings), you can create
+custom fields that are available to the SDKs. These custom fields can be used to add additional logic to your
+A/B experiments.
+
+:::info
+This feature is currently supported by the following SDKs:
+- Java
+- Javascript
+- Swift
+- Ruby
+:::
+
+## An Example
+
+Let's say you wish to override an experiment's allocation to a specific variant if they are a member of your development team.
+
+### Creating a Custom Field
+
+Checkout the [docs on creating a custom field](/docs/web-console-docs/settings#custom-fields) for more information on
+adding a field to your experiment creation form, but for this example, we'll create a field with
+the following properties:
+- **Name**: `Developers' variant`
+- **Type**: `number`
+- **Help Text**: `The variant to allocate to developers when they are testing the app in production.`
+- **Default Value**: `1`
+- **Field Required**: `true`
+- **Available?**: `true`
+- **Field Key**: `developer_variant`
+- **Section**: `Description`
+
+:::note
+You may wish to [create a custom section](/docs/web-console-docs/settings#custom-fields) for this field.
+:::
+
+### Using the Custom Field
+
+Now, when creating an experiment, you will see the custom field in the metadata section with a default value of `1`.
+If your experiment has more than one variant, you could change it per experiment to be `2` or `3`, or you could change
+it to `0`, if you wish for developers to only see the control variant.
+
+Now, in your app, you can pull the custom field value from the SDK context and use it to override the
+`context.treatment()` call. Here, we are assuming that the app's `user` object has an `isDeveloper` property.
+
+```ts
+const context = sdk.createContext(...);
+await context.ready();
+
+const experimentNames = context.experiments();
+for (const experimentName of experimentNames) {
+  const developerVariant = context.customFieldValue(experimentName, "developer_variant");
+
+  if (developerVariant != null && user.isDeveloper) {
+      context.override(experimentName, developerVariant);
+  }
+}
+```
+
+This code gets the list of experiment names, gets the `developer_variant` custom field value for each experiment, and
+if the current user is a developer, it overrides the experiment allocation to the variant that was set in the Web
+Console. If the user is not a developer, the experiment will run as normal. The `developer_variant` can also be
+edited on the Web Console to change the variant that developers see.
+
+:::caution
+Overriding an experiment allocation will not count the user towards the experiment data.
+To learn more about overrides, have a look at the [overrides SDK documentation](/docs/SDK-Documentation/basic-usage#overriding-treatment-variants).
+:::
+
+## Conclusion
+
+This is just one example of how custom fields can be used to add logic to your experiments, but there are many more!
+If you have any questions, please feel free reach out to us on Slack or via email.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -15,7 +15,7 @@ const config = {
   onBrokenMarkdownLinks: "warn",
   favicon: "img/favicon.ico",
 
-  //Speeding up the build with swc - was 2m34s on M1 Macbook, now 1m29s
+  // Speeding up the build with swc - was 2m34s on M1 Macbook, now 1m29s
   webpack: {
     jsLoader: (isServer) => ({
       loader: require.resolve('swc-loader'),


### PR DESCRIPTION
This PR adds a page to the `Advanced` section of the SDK docs that explains how
to use custom fields in an application. Specifically, it shows how to override
experiment variant allocation for developers on a per-experiment basis.
