### PR TITLE
feature/Goal Retention from First Achievement

### DIFF
--- a/docs/web-console-docs/tutorial.mdx
+++ b/docs/web-console-docs/tutorial.mdx
@@ -130,7 +130,8 @@ the form. You can learn more about these in the
 #### Goal Retention
 
 `Goal Retention` metrics are used to track data when a user has achieved a 
-goal after a set number of days from when they were exposed to the experiment.
+goal after a set period of time from when they were first exposed to 
+the experiment or from their first achievement of the same goal.
 
 For example, you could track whether users who left items in their checkout 
 cart came back to make a purchase after one week (maybe after receiving an 


### PR DESCRIPTION
This PR adds a line to the "Creating a Metric" tutorial to include that goal retention metrics can now be set from either the first exposure to the experiment, or the first achievement of the goal.
