### PR TITLE
fix: broken urls in experiment reports page

### DIFF
--- a/docs/web-console-docs/Aborting-experiments.mdx
+++ b/docs/web-console-docs/Aborting-experiments.mdx
@@ -47,7 +47,7 @@ If the treatment introduces a **bug** or **technical failure** that disrupts cor
 A bug in the checkout flow prevents users from completing transactions, making it imperative to abort the experiment immediately.
 
 ### Experiment Health Checks alert
-[Health Checks](experiment-health-checks) are quality checks run in the background to ensure the experiment and data are reliable. Most health checks alerts would require to abort the experiment and investigate the reason for the alert.
+[Health Checks](/docs/web-console-docs/experiment-health-checks) are quality checks run in the background to ensure the experiment and data are reliable. Most health checks alerts would require to abort the experiment and investigate the reason for the alert.
 
 **Example**:
 The health checks show an assignment conflicts was detected meaning that some visitors have been exposed to more than one variant. This might require the experiment to be stopped and the issue investigated.

--- a/docs/web-console-docs/Experiment-health-checks.mdx
+++ b/docs/web-console-docs/Experiment-health-checks.mdx
@@ -58,7 +58,7 @@ The experiment should be aborted and the reasons for SRM should be investigated.
 
 ### Audience Mismatch
 **What is it?**  
-Ensures that the actual audience for the experiment matches the intended target audience.  This check is only performed when [Audience Enforced is turned off](creating-an-experiment#targeting-audience). This serves as a reminder to put the required checks in your code to separate that targeting audience.
+Ensures that the actual audience for the experiment matches the intended target audience.  This check is only performed when [Audience Enforced is turned off](/docs/web-console-docs/creating-an-experiment#targeting-audience). This serves as a reminder to put the required checks in your code to separate that targeting audience.
 
 **Why is it important?**  
 It means that a non-intended audience is being exposed to your changes.Including the wrong audience can dilute the experiment’s impact and obscure meaningful insights.
@@ -86,7 +86,7 @@ Assess the risk of the interaction and both one or both of the experiments to el
 
 ### Variables Conflicting
 **What is it?**  
-Checks for conflicting variables used across 2 or more experiments. This check is performed when [Experiment Variables](creating-an-experiment#variant-variables) are used in the experiment setup.
+Checks for conflicting variables used across 2 or more experiments. This check is performed when [Experiment Variables](/docs/web-console-docs/creating-an-experiment#variant-variables) are used in the experiment setup.
 
 **Why is it important?**  
 Variable conflicts can impact the reliability of the experiments and can have a negative impact on the user experience.

--- a/docs/web-console-docs/Experiment-reports.mdx
+++ b/docs/web-console-docs/Experiment-reports.mdx
@@ -79,8 +79,8 @@ Even if an experiment was running only for a few seconds it would appear on the 
 <Image img="experiment-report/experiments-completed.png" alt="Experiments completed report" maxWidth="30rem" />
 
 This report highlights the number of experiment which were successfully completed in the reporting period. 
-In the case of a [Fixed Horizon Experiment](types-of-analysis), it is deemed completed once it reaches its expected sample size or planned duration.
-For a [Group Sequential Test](types-of-analysis), an experiment is completed once it crosses one of the test boundaries (efficiency or futility).
+In the case of a [Fixed Horizon Experiment](/docs/web-console-docs/types-of-analysis), it is deemed completed once it reaches its expected sample size or planned duration.
+For a [Group Sequential Test](/docs/web-console-docs/types-of-analysis), an experiment is completed once it crosses one of the test boundaries (efficiency or futility).
 
 The report also visualises the outcome of the statistical test on the primary metric at the moment the experiment was completed. 
 The experiment will be shown in `green` if its **primary metric was significant in the expected direction** at the time the experiment was completed.
@@ -102,7 +102,7 @@ Knowing that something does not have the expected impact on customer behaviour c
 In the case of **early stopped experiments** (also known as aborted experiments), the decisions to abort can happen because of bugs in the implementation, 
 early worrying negative signals, strategic reasons or for any other reason. 
 Depending on the reason for early stopping, aborted experiments are typically restarted once the underlying issue is fixed. 
-Read our [When to abort an experiment?](Aborting-experiments) guide to understand more about aborting experiments.
+Read our [When to abort an experiment?](/docs/web-console-docs/Aborting-experiments) guide to understand more about aborting experiments.
 
 While aborting experiments is common and part of the process, **early full on**, should be rare as they indicate that changes were pushed without supporting evidence.
 This can sometimes happen for strategic or legal reasons but because the experiment did not complete, it does not provide the reliable evidence needed to support or discard the underlying hypothesis.
@@ -140,7 +140,7 @@ It is nonetheless possible for `Full on` decisions to not be fully supported by 
 Currently a `Full on` decision is shown as supported by evidence **if and only if the experiment was completed and the primary metric is significant in the expected direction**.
 
 :::caution
-The supported by evidence validation does not currently includes checks on the secondary and guardrail metrics nor on the experiment [health checks](experiment-health-checks).
+The supported by evidence validation does not currently includes checks on the secondary and guardrail metrics nor on the experiment [health checks](/docs/web-console-docs/experiment-health-checks).
 :::
 
 
@@ -160,7 +160,7 @@ This typically happens when the evidence does not support the hypothesis.
 This widget provides a view on how many `Abort` decisions were made in the reporting period. 
 Aborting means stopping an experiment before it is completed. Aborting can happen when a bug is found or 
 when early negative signals indicate a possible degradation in certain key metrics but it could also be a strategic choice to stop early.
-Read our [When to abort an experiment?](Aborting-experiments) guide to understand more about aborting experiments.
+Read our [When to abort an experiment?](/docs/web-console-docs/Aborting-experiments) guide to understand more about aborting experiments.
 Like with `Keep current` decisions, `Abort` decisons means that the current experience remains but unlike `Keep current` decisions it does not say anything about the hypothesis being tested or not.
 
 ## Decisions history

--- a/docs/web-console-docs/creating-an-experiment.mdx
+++ b/docs/web-console-docs/creating-an-experiment.mdx
@@ -13,7 +13,7 @@ To get started with creating a new experiment, you can click **Experiments** on 
 
 :::info
 Instead of creating an experiment from scratch you can also decide to use a pre-existing template. 
-To find out more about creating and using templates check our [template documentation](templates).
+To find out more about creating and using templates check our [template documentation](/docs/web-console-docs/templates).
 :::
 
 ## Basics
@@ -80,6 +80,7 @@ Screenshots are useful to quickly understand what an experiment is changing.
 The audiences’ step is where you will control where the experiment will run and who will be exposed to it.
 
 <Image maxWidth="40rem" centered img="experiment-create/step-3.png" alt="Defining the audience" />
+
 ### Tracking Unit
 
 The **tracking unit** refers to the unique identifier used to identify the visitors of your experiment.
@@ -92,12 +93,12 @@ If the experiment is to run on a part of the product where visitors are not logg
 ABsmarty does not create nor use any third-party cookie. It is the responsibility of the experimenters to provide a unique identifier for the visitors of the experiment and if needed to store it in a first-party cookie.
 ::: 
 
-You can create new tracking units (there is no limit to the number of identifier you create) in your [dashboard settings](settings.mdx#units).
+You can create new tracking units (there is no limit to the number of identifier you create) in your [dashboard settings](/docs/web-console-docs/settings#units).
 ### Applications
 
 **Applications** defined where this experiment will run. An experiment can be running on several platforms at the same time.
 
-These could be `android`, `ios` and `web`, for example, and are also created in your [dashboard settings](settings.mdx#applications).
+These could be `android`, `ios` and `web`, for example, and are also created in your [dashboard settings](/docs/web-console-docs/settings#applications).
 ### Targeting Audience
 
 In this section you can define which particular audience will be exposed to the experiment. For example, you could decide to only run the experiment for visitors on an `android` device or visitors whose language is set to `english`. 
@@ -118,7 +119,7 @@ ABsmartly will only warn you when visitors not matching the audience are exposed
 ## Metrics
 
 In this section you can define the metrics to use to test your hypothesis and to measure the impact of your experiment.
-You can learn more about experimentation metrics in our [Understanding Experimentation Metrics](understanding-experimentation-metrics) article.
+You can learn more about experimentation metrics in our [Understanding Experimentation Metrics](/docs/web-console-docs/understanding-experimentation-metrics) article.
 ### The Primary Metric
 The **Primary Metric** is the main metric you are trying to impact as a result of the change. 
 This is the metric which ABsmartly uses to compute the test statistics and it is the main metric which will be used to decide if the hypothesis is tested or not.
@@ -193,7 +194,7 @@ It is good practice to have a set of guardrail metrics agreed upon and shared by
 To improve their usefulness, it is possible to define on the metric’s page, a threshold at which an alert would be triggered so you don’t miss it.
 Depending on the severity of the issues they signal, **Guardrail Metrics** can be used both for early stopping of experiments and to assess their impact at decision time. 
 
-For more information on early stopping of experiments using ABsmartly you can read our [**early stopping guide**](aborting-experiments).
+For more information on early stopping of experiments using ABsmartly you can read our [**early stopping guide**](/docs/web-console-docs/aborting-experiments).
 
 ### The Exploratory Metrics
 
@@ -221,12 +222,12 @@ Below are a few examples of what Primary, Secondary and Guardrail metrics could 
 ## Analysis
 
 In this step, you can choose and set up the analysis type you want to use.
-To choose between a Group Sequential or Fixed Horizon analysis check our [analysis type article](types-of-analysis).
+To choose between a Group Sequential or Fixed Horizon analysis check our [analysis type article](/docs/web-console-docs/types-of-analysis).
 
 To continue to properly set up your experiment refer to the relevant setup guide
 
-- [**Group Sequential setup guide**](setting-up-a-gst-experiment)
-- [**Fixed Horizon setup guide**](setting-up-a-fixed-horizon-experiment)
+- [**Group Sequential setup guide**](/docs/web-console-docs/setting-up-a-gst-experiment)
+- [**Fixed Horizon setup guide**](/docs/web-console-docs/setting-up-a-fixed-horizon-experiment)
 
 ## Metadata
 

--- a/docs/web-console-docs/tutorial.mdx
+++ b/docs/web-console-docs/tutorial.mdx
@@ -16,7 +16,7 @@ your experiments.
 
 ---
 
-You're almost ready to start [creating your first experiment](creating-an-experiment)!
+You're almost ready to start [creating your first experiment](/docs/web-console-docs/creating-an-experiment)!
 But first we have to tell the dashboard **how**, **where** and **why** you want to run
 your tests.
 
@@ -63,7 +63,7 @@ or kebab-case name. For example, `newsletter_subscription`, `cpu_load_time` or
 `bookings`.
 
 :::info Tip
-[Tags](settings#tags) are useful for searching, filtering and classifying your
+[Tags](/docs/web-console-docs/settings#tags) are useful for searching, filtering and classifying your
 goals. We recommend prefixing each tag with the tag's type. For example,
 `location:Header`, `stack:Backend` or `psychological:Trust`.
 :::
@@ -341,4 +341,4 @@ There are five options:
 ## The Next Step
 
 Now you have your units, applications, goals and metrics set up, you're ready to move
-on to the next chapter - [creating an experiment](creating-an-experiment)!
+on to the next chapter - [creating an experiment](/docs/web-console-docs/creating-an-experiment)!

--- a/docs/web-console-docs/types-of-analysis.mdx
+++ b/docs/web-console-docs/types-of-analysis.mdx
@@ -1,5 +1,3 @@
-Type-of-analysis.mdx
-
 ---
 sidebar_position: 9
 ---


### PR DESCRIPTION
This PR fixes a couple of broken links in the docs, as well as the "Types of analysis" page