### PR TITLE
feat: add double underscore note to varibale conflict alert

### DIFF
--- a/docs/web-console-docs/Experiment-health-checks.mdx
+++ b/docs/web-console-docs/Experiment-health-checks.mdx
@@ -88,6 +88,10 @@ Assess the risk of the interaction and both one or both of the experiments to el
 **What is it?**  
 Checks for conflicting variables used across 2 or more experiments. This check is performed when [Experiment Variables](/docs/web-console-docs/creating-an-experiment#variant-variables) are used in the experiment setup.
 
+:::caution
+Variable keys that are prefixed with a double underscore (`__`) are ignored during this health check.
+:::
+
 **Why is it important?**  
 Variable conflicts can impact the reliability of the experiments and can have a negative impact on the user experience.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a caution note to the “Variables Conflicting” health check explaining that keys prefixed with a double underscore (__) are ignored by this check.
  * Clarifies expected behaviour for variable naming and helps users understand which keys are evaluated.
  * No functional changes to the product; this update improves guidance and reduces potential confusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->