### PR TITLE
docs: add system attributes documentation for JavaScript SDK

### DIFF
--- a/docs/APIs-and-SDKs/SDK-Documentation/Advanced/context-attributes.mdx
+++ b/docs/APIs-and-SDKs/SDK-Documentation/Advanced/context-attributes.mdx
@@ -3,7 +3,12 @@ sidebar_position: 4
 ---
 
 import SettingContextAttributes from "./context-attributes/setting-context-attributes/_setting-context-attributes.mdx";
+import SystemAttributes from "./context-attributes/system-attributes/_system-attributes.mdx";
 
 # Context Attributes
 
 <SettingContextAttributes />
+
+## System Attributes
+
+<SystemAttributes />

--- a/docs/APIs-and-SDKs/SDK-Documentation/Advanced/context-attributes/system-attributes/_system-attributes.mdx
+++ b/docs/APIs-and-SDKs/SDK-Documentation/Advanced/context-attributes/system-attributes/_system-attributes.mdx
@@ -33,6 +33,22 @@ user-defined attributes in every publish payload:
 | `environment` | The environment from the SDK configuration |
 | `app_version` | The application version, only included if greater than `0` |
 
+:::note
+The `app_version` attribute is derived from the `application` option passed
+during SDK initialization. To set it, pass `application` as an object instead
+of a string:
+
+```javascript
+const sdk = new absmartly.SDK({
+  // ...
+  application: { name: "your-app", version: 3 },
+});
+```
+
+If `application` is passed as a plain string, the version defaults to `0` and
+`app_version` will not be included.
+:::
+
 :::info
 System attributes are disabled by default to avoid adding extra data to the
 payload for existing integrations. You must explicitly opt-in by setting

--- a/docs/APIs-and-SDKs/SDK-Documentation/Advanced/context-attributes/system-attributes/_system-attributes.mdx
+++ b/docs/APIs-and-SDKs/SDK-Documentation/Advanced/context-attributes/system-attributes/_system-attributes.mdx
@@ -31,17 +31,17 @@ user-defined attributes in every publish payload:
 | `sdk_version` | The SDK version (e.g. `"1.13.4"`) |
 | `application` | The application name from the SDK configuration |
 | `environment` | The environment from the SDK configuration |
-| `app_version` | The application version, only included if greater than `0` |
+| `app_version` | The application version, only included if set (number greater than `0` or non-empty string) |
 
 :::note
 The `app_version` attribute is derived from the `application` option passed
 during SDK initialization. To set it, pass `application` as an object instead
-of a string:
+of a string. The version can be a number or a semver string:
 
 ```javascript
 const sdk = new absmartly.SDK({
   // ...
-  application: { name: "your-app", version: 3 },
+  application: { name: "your-app", version: "1.2.3" },
 });
 ```
 

--- a/docs/APIs-and-SDKs/SDK-Documentation/Advanced/context-attributes/system-attributes/_system-attributes.mdx
+++ b/docs/APIs-and-SDKs/SDK-Documentation/Advanced/context-attributes/system-attributes/_system-attributes.mdx
@@ -1,0 +1,40 @@
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import CodeBlock from "@theme/CodeBlock";
+
+import JsSystemAttributes from "!!raw-loader!./js/systemAttributes.js";
+
+You can opt-in to automatically include system attributes in every publish
+payload. These attributes provide metadata about the SDK and environment that
+generated the event, which can be useful for debugging and filtering in the Web
+Console.
+
+To enable this, set the `includeSystemAttributes` option to `true` when creating
+the context:
+
+<Tabs groupId="language">
+
+<TabItem value="js" label="Javascript">
+
+<CodeBlock language="js">{JsSystemAttributes}</CodeBlock>
+
+</TabItem>
+
+</Tabs>
+
+When enabled, the following attributes are automatically prepended before any
+user-defined attributes in every publish payload:
+
+| Attribute | Description |
+|:---|---|
+| `sdk_name` | The SDK agent name (e.g. `"absmartly-javascript-sdk"`) |
+| `sdk_version` | The SDK version (e.g. `"1.13.4"`) |
+| `application` | The application name from the SDK configuration |
+| `environment` | The environment from the SDK configuration |
+| `app_version` | The application version, only included if greater than `0` |
+
+:::info
+System attributes are disabled by default to avoid adding extra data to the
+payload for existing integrations. You must explicitly opt-in by setting
+`includeSystemAttributes: true`.
+:::

--- a/docs/APIs-and-SDKs/SDK-Documentation/Advanced/context-attributes/system-attributes/js/systemAttributes.js
+++ b/docs/APIs-and-SDKs/SDK-Documentation/Advanced/context-attributes/system-attributes/js/systemAttributes.js
@@ -1,0 +1,3 @@
+const context = sdk.createContext(request, {
+  includeSystemAttributes: true,
+});

--- a/docs/APIs-and-SDKs/SDK-Documentation/getting-started/import-and-initialize/js/import.js
+++ b/docs/APIs-and-SDKs/SDK-Documentation/getting-started/import-and-initialize/js/import.js
@@ -10,3 +10,6 @@ const sdk = new absmartly.SDK({
   environment: process.env.NODE_ENV,
   application: process.env.APPLICATION_NAME,
 });
+
+// You can also pass application as an object to track the app version:
+// application: { name: "your-app", version: 3 }

--- a/docs/APIs-and-SDKs/SDK-Documentation/getting-started/import-and-initialize/js/import.js
+++ b/docs/APIs-and-SDKs/SDK-Documentation/getting-started/import-and-initialize/js/import.js
@@ -11,5 +11,6 @@ const sdk = new absmartly.SDK({
   application: process.env.APPLICATION_NAME,
 });
 
-// You can also pass application as an object to track the app version:
-// application: { name: "your-app", version: 3 }
+// You can also pass application as an object to track the app version.
+// The version can be a number or a semver string:
+// application: { name: "your-app", version: "1.2.3" }


### PR DESCRIPTION
## Summary
- Add System Attributes section to the Context Attributes documentation page
- Document the `includeSystemAttributes` context option with JS code example
- List all system attributes (`sdk_name`, `sdk_version`, `application`, `environment`, `app_version`) with descriptions

## Related
- SDK PR: absmartly/javascript-sdk (feat/sdk-version-in-payload)

## Test plan
- [ ] Verify page renders correctly in Docusaurus
- [ ] Verify code tabs display properly
- [ ] Verify attribute table renders correctly