### PR TITLE
fix: add CLI to Developer Tools overview, dedupe MCP Setup title

### DIFF
--- a/docs/APIs-and-SDKs/CLI-Documentation/authentication.mdx
+++ b/docs/APIs-and-SDKs/CLI-Documentation/authentication.mdx
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Authentication
 
-The CLI stores credentials in your OS keychain (via keytar) and configuration in `~/.config/absmartly/config.yaml`. On headless systems without a keychain service, credentials fall back to `~/.config/absmartly/credentials.json` (chmod 600).
+The CLI stores credentials in your OS keychain (via keytar) and configuration in `~/.config/absmartly/config.yaml`. On headless systems without a keychain service, credentials fall back to a local `~/.config/absmartly/credentials.json` file.
 
 Two authentication methods are supported.
 
@@ -14,8 +14,8 @@ Two authentication methods are supported.
 # Login with API key
 abs auth login --api-key YOUR_KEY --endpoint https://your-instance.absmartly.com/v1
 
-# Login with a named profile
-abs auth login --api-key YOUR_KEY --endpoint https://staging.absmartly.com/v1 --profile staging
+# Login with a named profile (e.g. for a read-only key)
+abs auth login --api-key YOUR_READONLY_KEY --endpoint https://your-instance.absmartly.com/v1 --profile readonly
 ```
 
 ## OAuth authentication
@@ -49,7 +49,7 @@ The `-k` flag disables TLS certificate verification. Only use in trusted develop
 # Check authentication status
 abs auth status
 abs auth status --show-key    # reveal full API key
-abs auth status --profile staging
+abs auth status --profile readonly
 
 # Show current authenticated user
 abs auth whoami
@@ -71,7 +71,7 @@ abs auth reset-my-password
 
 # Logout
 abs auth logout
-abs auth logout --profile staging
+abs auth logout --profile readonly
 ```
 
 You can also override credentials per-command with global options:

--- a/docs/APIs-and-SDKs/CLI-Documentation/configuration.mdx
+++ b/docs/APIs-and-SDKs/CLI-Documentation/configuration.mdx
@@ -39,7 +39,7 @@ abs config unset output
 
 # Manage profiles
 abs config profiles list
-abs config profiles use staging
+abs config profiles use readonly
 abs config profiles delete old-profile
 ```
 
@@ -57,12 +57,12 @@ profiles:
       endpoint: https://ctl.absmartly.io/v1
     application: my-app
     environment: production
-  staging:
+  readonly:
     api:
-      endpoint: https://staging.absmartly.com/v1
+      endpoint: https://your-instance.absmartly.com/v1
     expctld:
       endpoint: https://ctl.absmartly.io/v1
-    environment: staging
+    environment: production
 ```
 
 ### Environment variables

--- a/docs/APIs-and-SDKs/CLI-Documentation/index.mdx
+++ b/docs/APIs-and-SDKs/CLI-Documentation/index.mdx
@@ -13,18 +13,6 @@ The CLI wraps the same Platform API used by the web console, so anything you can
 This project is experimental. The core architecture is settled, but the API surface may change between releases.
 :::
 
-| Area | Status |
-|---|---|
-| Experiment commands (list, get, create, update, start, stop, restart, clone, bulk) | Stable — well tested |
-| Metric results, CI bars, segment breakdowns | Stable |
-| Template round-trip (export → edit → create/update) | Stable |
-| Core layer (`@absmartly/cli/core/*`) for programmatic use | Stable — 444 unit tests |
-| Admin commands (tags, roles, teams, users, webhooks, etc.) | Mostly stable — less battle-tested |
-| OAuth authentication | Working — tested against live API |
-| Interactive editor (`--interactive` / `-i` flag) | Experimental — known issues, not production-ready |
-| Shell completions | Working — may have gaps |
-| Unix pipe composition | Stable |
-
 ## Installation
 
 ```bash
@@ -41,7 +29,9 @@ abs setup
 
 # Non-interactive setup
 abs setup --api-key YOUR_KEY --endpoint https://your-instance.absmartly.com/v1
-abs setup --api-key YOUR_KEY --endpoint https://staging.absmartly.com/v1 --profile staging
+
+# Non-interactive setup with a named profile (e.g. for a read-only key)
+abs setup --api-key YOUR_READONLY_KEY --endpoint https://your-instance.absmartly.com/v1 --profile readonly
 
 # Or authenticate manually
 abs auth login --api-key YOUR_API_KEY --endpoint https://your-instance.absmartly.com/v1

--- a/docs/APIs-and-SDKs/MCP-Server/setup.mdx
+++ b/docs/APIs-and-SDKs/MCP-Server/setup.mdx
@@ -1,6 +1,7 @@
 ---
 title: Setup
 sidebar_position: 3
+hide_title: true
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/APIs-and-SDKs/MCP-Server/setup.mdx
+++ b/docs/APIs-and-SDKs/MCP-Server/setup.mdx
@@ -1,7 +1,6 @@
 ---
 title: Setup
 sidebar_position: 3
-hide_title: true
 ---
 
 import Tabs from "@theme/Tabs";
@@ -28,8 +27,6 @@ export const CursorInstallLink = () => (
     {() => <a href={cursorInstallUrl}>Add to Cursor</a>}
   </BrowserOnly>
 );
-
-# Setup
 
 The ABsmartly MCP server can be added to any MCP-compatible client. This page
 covers Claude Desktop, Claude Code, Cursor, Windsurf, VS Code (Copilot), Gemini

--- a/docs/APIs-and-SDKs/overview.mdx
+++ b/docs/APIs-and-SDKs/overview.mdx
@@ -84,6 +84,21 @@ Common starting points:
 - [Usage Examples](/docs/APIs-and-SDKs/MCP-Server/usage-examples) — natural-language prompts that work today
 - [Tools Reference](/docs/APIs-and-SDKs/MCP-Server/tools-reference) — the full surface: 230+ commands across 33 groups
 
+### CLI
+
+The [CLI](/docs/APIs-and-SDKs/CLI-Documentation/) is a command-line interface
+for AI agents and humans to manage experiments, feature flags and A/B tests on
+the ABsmartly platform. It wraps the same Platform API used by the web
+console, so anything you can do in the dashboard, you can automate from a
+terminal or a script.
+
+Common starting points:
+
+- [CLI Overview](/docs/APIs-and-SDKs/CLI-Documentation/) — installation and quick start
+- [Authentication](/docs/APIs-and-SDKs/CLI-Documentation/authentication) — the full login flow
+- [Experiments & Feature Flags](/docs/APIs-and-SDKs/CLI-Documentation/experiments-and-feature-flags) — the primary command reference
+- [Programmatic Usage](/docs/APIs-and-SDKs/CLI-Documentation/programmatic-usage) — call the CLI's core layer directly from TypeScript/JavaScript
+
 ---
 
 ## Which one should I use?
@@ -95,6 +110,7 @@ Common starting points:
 | Create, manage or query experiments programmatically | [Platform API](/docs/APIs-and-SDKs/Web-Console-API/backend) |
 | Build automation, internal tools, or CI/CD integrations | [Platform API](/docs/APIs-and-SDKs/Web-Console-API/backend) |
 | Drive ABsmartly from Claude, Cursor or another AI assistant | [MCP Server](/docs/APIs-and-SDKs/MCP-Server/overview) |
+| Manage experiments from a terminal or CI/CD script | [CLI](/docs/APIs-and-SDKs/CLI-Documentation/) |
 | Visually edit pages for an A/B test without writing code | [LaunchPad browser extension](/docs/web-console-docs/launchpad-browser-extension/getting-started) |
 | Run experiments and configure the workspace from the UI | [Product Documentation](/docs/web-console-docs/overview) |
 


### PR DESCRIPTION
## Summary
- The Developer Tools overview page (`docs/APIs-and-SDKs/overview.mdx`) listed SDK Guide, SDK API, Platform API and MCP Server but never mentioned the CLI, even though it has its own sidebar category (`CLI-Documentation`). Added a "CLI" section and a row in the "Which one should I use?" table.
- The MCP Server Setup page (`docs/APIs-and-SDKs/MCP-Server/setup.mdx`) rendered the "Setup" title twice. Root cause: the page has `export const ...` MDX declarations before its in-content `# Setup` H1. Docusaurus's `parseMarkdownContentTitle` only strips leading `import` statements, not `export`, so it never finds the H1 and falls back to rendering the frontmatter `title: Setup` as a synthetic heading — on top of the literal `# Setup` already in the content. Fixed by removing the redundant `# Setup` heading from the content itself (simpler than `hide_title: true`, per review feedback), so the frontmatter `title` renders as the only H1.
- Removed the "Area / Status" stability table from the CLI overview page (`CLI-Documentation/index.mdx`) — it read like an internal engineering tracker rather than customer-facing docs.
- Reworded the `--profile staging` examples across `CLI-Documentation/index.mdx`, `authentication.mdx` and `configuration.mdx`. Customers only ever have one ABsmartly instance, so an example profile pointed at a different endpoint (`staging.absmartly.com`) was misleading. Profiles are more realistically used to switch between credentials with different permissions (e.g. a read-only key), so all examples now use a `readonly` profile against the same instance.
- Dropped the parenthetical `(chmod 600)` from the CLI Authentication page's intro paragraph — an implementation detail that read oddly out of context for docs.

## Test plan
- [x] Ran `yarn install` + `npx docusaurus start` in an isolated worktree and confirmed the dev build compiles successfully
- [x] Verified via Playwright that `/docs/APIs-and-SDKs/MCP-Server/setup` now renders exactly one `<h1>Setup</h1>`
- [x] Verified `/docs/APIs-and-SDKs/overview` now shows a CLI section with working links to `CLI-Documentation` pages, and a CLI row in the comparison table
- [x] Verified `/docs/APIs-and-SDKs/CLI-Documentation/` no longer shows the status table, and `/docs/APIs-and-SDKs/CLI-Documentation/authentication` no longer shows `(chmod 600)` and uses `readonly` profile examples
- [x] Screenshots confirmed visually (before/after match the reported bugs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new CLI section to the APIs and SDKs overview, including links to common starting points.
  * Updated the “Which one should I use?” table with a row directing users to the CLI for experiment management from terminal or CI/CD workflows.
  * Updated CLI documentation examples to use `readonly` profiles (instead of `staging`) for authentication and configuration.
  * Cleaned up the MCP Server setup page by relying on the existing page title for heading display.
  * Removed the “Area / Status” stability table from the ABsmartly CLI overview section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
