### PR TITLE
ci: update GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/algolia.yml
+++ b/.github/workflows/algolia.yml
@@ -10,7 +10,7 @@ jobs:
     name: "Update Algolia"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Get Algolia config
         id: algolia_config

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,10 @@ jobs:
     name: Yarn Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set Node.js 20.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 20.x
 

--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -31,7 +31,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         id: create-combined-pr
         name: Create Combined PR
         with:


### PR DESCRIPTION
Updates all first-party GitHub Actions to their latest major versions.

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `actions/setup-node` | v4 | v7 |
| `actions/github-script` | v7 | v9 |

`signcl/docsearch-scraper-action@master` left as-is — third-party action pinned to a branch, no semver tag to bump.

## Breaking change review

Checked each changelog against our actual usage — none of the breaking changes apply:

- **checkout v5/v6/v7**: Node 24 runtime (runner requirement met by `ubuntu-latest`); v7's fork-PR block only affects `pull_request_target`/`workflow_run`, which we don't use.
- **setup-node v5**: auto-caching triggers on a `packageManager` field in `package.json` — we have none, so no behavior change.
- **github-script v9**: ESM migration drops `require('@actions/github')` and injects `getOctokit`. Our `combine-prs.yml` script uses only the injected `github` client (`github.paginate`, `github.graphql`, `github.rest.*`) — unaffected.

Note: `feature/docsearch-on-deploy-plugin` also has these actions at the old versions and touches the same workflow files. It'll hit a trivial version conflict on merge — take the bumped versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated build and deployment workflows to use newer versions of repository checkout, Node.js setup, and GitHub scripting tools.
  * No user-facing functionality or behaviour has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->